### PR TITLE
raw procfs: use O_NOFOLLOW for all fdinfo opens

### DIFF
--- a/src/utils/raw_procfs.rs
+++ b/src/utils/raw_procfs.rs
@@ -260,3 +260,126 @@ impl<'fd> RawProcfsRoot<'fd> {
         Ok(fd)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::error::ErrorKind;
+
+    use pretty_assertions::assert_matches;
+
+    #[test]
+    fn exists_unchecked() {
+        assert_matches!(
+            RawProcfsRoot::UnsafeGlobal
+                .exists_unchecked("nonexist")
+                .map_err(|err| err.kind()),
+            Err(ErrorKind::OsError(Some(libc::ENOENT))),
+            r#"exists_unchecked("nonexist") -> ENOENT"#
+        );
+        assert_matches!(
+            RawProcfsRoot::UnsafeGlobal
+                .exists_unchecked("uptime")
+                .map_err(|err| err.kind()),
+            Ok(()),
+            r#"exists_unchecked("uptime") -> Ok"#
+        );
+    }
+
+    #[test]
+    fn open_beneath() {
+        assert_matches!(
+            RawProcfsRoot::UnsafeGlobal
+                .open_beneath("nonexist", OpenFlags::O_RDONLY)
+                .map_err(|err| err.kind()),
+            Err(ErrorKind::OsError(Some(libc::ENOENT))),
+            r#"open_beneath("nonexist") -> ENOENT"#
+        );
+        assert_matches!(
+            RawProcfsRoot::UnsafeGlobal
+                .open_beneath("self", OpenFlags::O_RDONLY)
+                .map_err(|err| err.kind()),
+            Err(ErrorKind::OsError(Some(libc::ELOOP))),
+            r#"open_beneath("self") -> ELOOP"#
+        );
+        assert_matches!(
+            RawProcfsRoot::UnsafeGlobal
+                .open_beneath("self/cwd", OpenFlags::O_RDONLY)
+                .map_err(|err| err.kind()),
+            Err(ErrorKind::OsError(Some(libc::ELOOP))),
+            r#"open_beneath("self/cwd") -> ELOOP"#
+        );
+        assert_matches!(
+            RawProcfsRoot::UnsafeGlobal
+                .open_beneath("self/status", OpenFlags::O_RDONLY)
+                .map_err(|err| err.kind()),
+            Ok(_),
+            r#"open_beneath("self/status") -> Ok"#
+        );
+    }
+
+    #[test]
+    #[cfg_attr(feature = "_test_enosys_openat2", ignore)]
+    fn openat2_beneath() {
+        assert_matches!(
+            RawProcfsRoot::UnsafeGlobal
+                .openat2_beneath("nonexist", OpenFlags::O_RDONLY)
+                .map_err(|err| err.kind()),
+            Err(ErrorKind::OsError(Some(libc::ENOENT))),
+            r#"openat2_beneath("nonexist") -> ENOENT"#
+        );
+        assert_matches!(
+            RawProcfsRoot::UnsafeGlobal
+                .openat2_beneath("self", OpenFlags::O_RDONLY)
+                .map_err(|err| err.kind()),
+            Err(ErrorKind::OsError(Some(libc::ELOOP))),
+            r#"openat2_beneath("self") -> ELOOP"#
+        );
+        assert_matches!(
+            RawProcfsRoot::UnsafeGlobal
+                .openat2_beneath("self/cwd", OpenFlags::O_RDONLY)
+                .map_err(|err| err.kind()),
+            Err(ErrorKind::OsError(Some(libc::ELOOP))),
+            r#"openat2_beneath("self/cwd") -> ELOOP"#
+        );
+        assert_matches!(
+            RawProcfsRoot::UnsafeGlobal
+                .openat2_beneath("self/status", OpenFlags::O_RDONLY)
+                .map_err(|err| err.kind()),
+            Ok(_),
+            r#"openat2_beneath("self/status") -> Ok"#
+        );
+    }
+
+    #[test]
+    fn opath_beneath_unchecked() {
+        assert_matches!(
+            RawProcfsRoot::UnsafeGlobal
+                .opath_beneath_unchecked("nonexist", OpenFlags::O_RDONLY)
+                .map_err(|err| err.kind()),
+            Err(ErrorKind::OsError(Some(libc::ENOENT))),
+            r#"opath_beneath_unchecked("nonexist") -> ENOENT"#
+        );
+        assert_matches!(
+            RawProcfsRoot::UnsafeGlobal
+                .opath_beneath_unchecked("self", OpenFlags::O_RDONLY)
+                .map_err(|err| err.kind()),
+            Err(ErrorKind::OsError(Some(libc::ELOOP))),
+            r#"opath_beneath_unchecked("self") -> ELOOP"#
+        );
+        assert_matches!(
+            RawProcfsRoot::UnsafeGlobal
+                .opath_beneath_unchecked("self/cwd", OpenFlags::O_RDONLY)
+                .map_err(|err| err.kind()),
+            Err(ErrorKind::OsError(Some(libc::ELOOP))),
+            r#"opath_beneath_unchecked("self/cwd") -> ELOOP"#
+        );
+        assert_matches!(
+            RawProcfsRoot::UnsafeGlobal
+                .opath_beneath_unchecked("self/status", OpenFlags::O_RDONLY)
+                .map_err(|err| err.kind()),
+            Ok(_),
+            r#"opath_beneath_unchecked("self/status") -> Ok"#
+        );
+    }
+}

--- a/src/utils/raw_procfs.rs
+++ b/src/utils/raw_procfs.rs
@@ -235,10 +235,10 @@ impl<'fd> RawProcfsRoot<'fd> {
         oflags: OpenFlags,
     ) -> Result<OwnedFd, Error> {
         let fd = if *syscalls::OPENAT2_IS_SUPPORTED {
-            self.openat2_beneath(path, oflags)?
+            self.openat2_beneath(path, oflags)
         } else {
-            self.opath_beneath_unchecked(path, oflags)?
-        };
+            self.opath_beneath_unchecked(path, oflags)
+        }?;
         // As this is called from within fetch_mnt_id as a fallback, the only
         // thing we can do here is verify that it is actually procfs. However,
         // in practice it will be quite difficult for an attacker to over-mount


### PR DESCRIPTION
Because RawProcfsHandle is only used for fdinfo/$n opens, we really
should be auto-applying O_NOFOLLOW. The only slightly odd point is that
the non-openat2 codepath splits the open into O_PATH and re-open, so we
need to handle O_NOFOLLOW a little differently.

Signed-off-by: Aleksa Sarai <cyphar@cyphar.com>