### PR TITLE
go-pathrs: don't derive ProcBase from the C enum

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
   handling of numerical C constants is somewhat compiler-dependent and some of
   our sanity checking code would previously fail to compile under `CC=clang`.
   (#401)
+- Previously, if a downstream regenerated our `include/pathrs.h` header with
+  using `cbindgen >= v0.29.3`, the header would use C23 features that would
+  cause go-pathrs to fail to build. We now have worked around the issue for
+  go-pathrs but we still have not updated our headers because our Python
+  bindings have other issues with the new headers. See the discussion in
+  mozilla/cbindgen#1156 for more details.
 
 ## [0.2.5] - 2026-06-17 ##
 

--- a/go-pathrs/internal/libpathrs/libpathrs_linux.go
+++ b/go-pathrs/internal/libpathrs/libpathrs_linux.go
@@ -217,7 +217,13 @@ func InRootHardlink(oldRootFd uintptr, oldPath string, newRootFd uintptr, newPat
 }
 
 // ProcBase is pathrs_proc_base_t (uint64_t).
-type ProcBase C.pathrs_proc_base_t
+//
+// FIXME: cbindgen v0.29.3 switched to outputting C23 fixed-type enum syntax
+// and making pathrs_proc_base_t a typedef of the enum. CGo treats all enum
+// members as an int64 despite the fixed-type declaration, causing spurious
+// errors about overflows. Thus we have to hardcode the type on the Go side.
+// See <https://github.com/mozilla/cbindgen/pull/1156>.
+type ProcBase uint64
 
 // FIXME: We need to open-code the constants because CGo's handling of
 // non-literal constants (i.e., those resolved using the C compiler) that don't


### PR DESCRIPTION
cbindgen v0.29.3 emits the C23 fixed-type enum syntax for sized enums[1], so in C23 mode pathrs_proc_base_t names the enum rather than uint64_t. CGo maps a C enum to a *signed* Go type, so none of the open-coded ProcBase constants fit in it any more and the package stops compiling:

> internal/libpathrs/libpathrs_linux.go:228:22: cannot use
> 0xFFFF_FFFE_7072_6F63 (untyped int constant 18446744067006164835) as
> ProcBase value in constant declaration (overflows)

Our own tree does not show this, because CI is pinned to cbindgen v0.29.2[2], so the checked-in header and the release tarball still typedef uint64_t. Fedora (and presumably other distros) do hit it, because they build the crate with `cargo-c`, which generates the header with its own cbindgen. Fedora rawhide has cbindgen v0.29.4 and gcc 16, which defaults to C23, so libpathrs-devel-0.2.5-2.fc45 ships the C23 spelling and every Go consumer of it fails to build. The workaround there is to force the older language version with `CGO_CFLAGS=-std=gnu17`.

Declare the type as plain uint64 instead, which is what the docstring already promises. That also holds up under the direction discussed in [1], where the #if guards would be dropped in favour of an opt-out and the enum spelling would become unconditional.

Nothing else has to change: the values were already converted with C.pathrs_proc_base_t() at each call site, and init() already reads the C constants through int64 temporaries because CGo signs those too.

[1]: https://github.com/mozilla/cbindgen/pull/1156
[2]: https://github.com/cyphar/libpathrs/pull/383