### PR TITLE
procfs: gracefully handle broken ProcfsHandle cache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,17 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
   bindings have other issues with the new headers. See the discussion in
   mozilla/cbindgen#1156 for more details.
 
+### Changed ###
+- runc closes all open file descriptors before executing user code in order to
+  avoid some particularly hairy security bugs. Unfortunately, this also
+  invalidates the cached `ProcfsHandle` in libpathrs, which could cause runc to
+  later crash if a subsequent procfs operation was attempted (which happened in
+  the error path of runc). Most downstream users will never run into this
+  issue, but we now handle the problem a bit more gracefully -- if libpathrs
+  detects this problematic condition, the cached handle is locked out of use
+  and all `ProcfsHandleBuilder::build` invocations will produce a new handle.
+  (#413, opencontainers/runc#5438)
+
 ## [0.2.5] - 2026-06-17 ##
 
 > Or, to save on postage, I'll just poison him with this!

--- a/src/procfs.rs
+++ b/src/procfs.rs
@@ -332,26 +332,47 @@ impl ProcfsHandleBuilder {
     /// underlying file descriptor for a [`ProcfsHandle`] returned by this
     /// method.
     ///
-    /// # Panics
-    ///
-    /// If the cached [`ProcfsHandle`] has been invalidated, this method will
-    /// panic as this is not a state that should be possible to reach in regular
-    /// program execution.
+    /// To avoid negatively impacting downstream projects, as a final safety
+    /// mechanism if the cached [`ProcfsHandle`] does become invalidated,
+    /// [`build`][Self::build] will refuse to use it and will always create new
+    /// handles. Users are still strongly recommended to not fiddle with file
+    /// descriptors in that way (unless absolutely necessary).
     pub fn build(self) -> Result<ProcfsHandle, Error> {
         // MSRV(1.70): Use std::sync::OnceLock.
         static CACHED_PROCFS_HANDLE: OnceLock<OwnedFd> = OnceLock::new();
+        static CACHED_HANDLE_IS_BAD: OnceLock<()> = OnceLock::new();
+
+        // Helper to make the lower conditional a bit easier to read.
+        fn is_cached_handle_bad() -> bool {
+            CACHED_HANDLE_IS_BAD.get().is_some()
+        }
 
         // MSRV(1.85): Use let chain here (Rust 2024).
-        if self.is_cache_friendly() {
+        if self.is_cache_friendly() && !is_cached_handle_bad() {
             // If there is already a cached filesystem available, use that.
             if let Some(fd) = CACHED_PROCFS_HANDLE.get() {
-                let procfs = ProcfsHandle::try_from_borrowed_fd(fd.as_fd())
-                    .expect("cached procfs handle should be valid");
-                debug_assert!(
-                    procfs.is_subset && procfs.is_detached,
-                    "cached procfs handle should be subset=pid and detached"
-                );
-                return Ok(procfs);
+                if let Ok(procfs) = ProcfsHandle::try_from_borrowed_fd(fd.as_fd()) {
+                    debug_assert!(
+                        procfs.is_subset && procfs.is_detached,
+                        "cached procfs handle should be subset=pid and detached"
+                    );
+                    return Ok(procfs);
+                }
+                // If the cached procfs handle failed to validate the file
+                // descriptor must have been closed or dup2'd over. Crashing
+                // here would be the most correct approach, but runc
+                // intentionally closes all file descriptors and so we might
+                // crash runc unexpectedly (see opencontainers/runc#5438).
+                //
+                // So, if the handle is bad (for any reason) we fall back to the
+                // creation behaviour and lock out any future attempts to use
+                // the handle (if a program has gotten into this kind of state
+                // it's best to not try to touch bad fds).
+                //
+                // TODO: We should probably log the error here, but logging in
+                // libraries really sucks...
+                let _ = CACHED_HANDLE_IS_BAD.set(());
+                // fallthrough to creation path
             }
         }
 
@@ -370,7 +391,7 @@ impl ProcfsHandleBuilder {
                 is_subset: true, // must be subset=pid to cache (risk: dangerous files)
                 is_detached: true, // must be detached to cache (risk: escape to host)
                 ..
-            } => {
+            } if !is_cached_handle_bad() => {
                 // Try to cache our new handle -- if another thread beat us to
                 // it, just use the handle that they cached and drop the one we
                 // created.

--- a/src/tests/test_procfs.rs
+++ b/src/tests/test_procfs.rs
@@ -42,8 +42,10 @@ use crate::{
 };
 use utils::ExpectedResult;
 
-use anyhow::Error;
-use rustix::mount::OpenTreeFlags;
+use std::os::unix::io::{AsFd, AsRawFd};
+
+use anyhow::{Context, Error};
+use rustix::{io as rustix_io, mount::OpenTreeFlags};
 
 macro_rules! procfs_tests {
     // Create the actual test functions.
@@ -346,6 +348,45 @@ procfs_tests! {
     proc_sym_opath_onofollow: open(self, "fd/1", O_PATH) => (error: Ok);
     proc_sym_odir_opath_onofollow: open(self, "fd/1", O_DIRECTORY|O_PATH) => (error: Err(ErrorKind::OsError(Some(libc::ENOTDIR))));
     proc_dir_odir_opath_onofollow: open(self, "fd", O_DIRECTORY|O_PATH) => (error: Ok);
+}
+
+// Regression test for <https://github.com/cyphar/libpathrs/issues/413> and
+// <https://github.com/opencontainers/runc/issues/5438>. Make sure that a broken
+// cached ProcfsHandle fd still does not cause a panic.
+#[test]
+#[cfg_attr(not(nextest), ignore)] // needs one-process-per-test scheme
+fn procfs_dead_cached_handle() -> Result<(), Error> {
+    // Construct a handle which will fill the cache.
+    let procfs = ProcfsHandleBuilder::new()
+        .build()
+        .context("get cached procfs handle")?;
+    let cached_fd = procfs.as_fd().as_raw_fd();
+    if procfs.into_owned_fd().is_some() {
+        // FIXME(libtest skip): use proper runtime skipping in the test.
+        eprintln!("procfs handle is not cached (missing privileges?)");
+        return Ok(());
+    }
+
+    // Emulate runc's "close fds before exec" behaviour.
+    // SAFETY: This *deliberately* violates I/O safety but is only done within
+    // nextest and thus no other tests will inherit this broken state.
+    unsafe { rustix_io::close(cached_fd) };
+
+    // TODO: Maybe we should dup2 over cached_fd?
+
+    for _ in 0..3 {
+        let procfs = ProcfsHandleBuilder::new()
+            .build()
+            .context("get procfs handle after cached fd was closed")?;
+        procfs
+            .open(ProcfsBase::ProcSelf, ".", OpenFlags::O_PATH)
+            .context("open /proc/self with replacement procfs handle")?;
+        assert!(
+            procfs.into_owned_fd().is_some(),
+            "handles created after the cache was invalidated should not be cached"
+        );
+    }
+    Ok(())
 }
 
 mod utils {


### PR DESCRIPTION
On paper, once we cache a ProcfsHandle, the file descriptor should be
okay for the lifetime of the process and so the .expect() lines around
the usage of the CACHED_PROCFS_HANDLE were reasonable.

Unfortunately, runc (as part of soem security hardening) has some logic
to forcefully close all file descriptors in a process, which breaks our
ProcfsHandle cache. If runc then happens to try to do some procfs
operation later then the whole process will crash[1].

To be a little bit more friendly to downstreams, we instead now handle
a bad CACHED_PROCFS_HANDLE by permanently locking out the usage of the
cache (to avoid further damage) and switch to always creating a new
ProcfsHandle even if the handle is cacheable. Ideally we would also log
something but we don't have a nice logging mechanism that would pipe
through to downstreams properly.

[1]: https://github.com/opencontainers/runc/issues/5438

Signed-off-by: Aleksa Sarai <cyphar@cyphar.com>