### PR TITLE
syscalls: compare filesystem types as u64s

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -82,23 +82,40 @@ jobs:
           - riscv64gc-unknown-linux-gnu
           - sparc64-unknown-linux-gnu
           - s390x-unknown-linux-gnu
+        include:
+          # rustup does not distribute a pre-built libstd for tier 3 targets
+          # (such as s390x-unknown-linux-musl), so for those targets we need
+          # to use nightly Rust and build libstd ourselves with -Zbuild-std.
+          - target: s390x-unknown-linux-musl
+            build-std: true
     name: cargo check (${{ matrix.target }})
     runs-on: ubuntu-latest
+    env:
+      # Only set for the targets where we need to build libstd ourselves.
+      BUILD_STD_FLAGS: ${{ matrix.build-std && '-Zbuild-std' || '' }}
     steps:
       - uses: actions/checkout@v7
       - uses: dtolnay/rust-toolchain@stable
+        if: ${{ !matrix.build-std }}
         with:
           # TODO: Should we use MSRV for this?
           targets: ${{ matrix.target }}
+      # -Zbuild-std requires nightly Rust (and the libstd sources).
+      - uses: dtolnay/rust-toolchain@nightly
+        if: ${{ matrix.build-std }}
+        with:
+          components: rust-src
       - uses: taiki-e/install-action@cargo-hack
       - name: cargo check --target=${{ matrix.target }}
         run: >-
           cargo hack --each-feature --keep-going \
-            check --target=${{ matrix.target }} --all-targets
+            check --target=${{ matrix.target }} --all-targets \
+            $BUILD_STD_FLAGS
       - name: cargo build --target=${{ matrix.target }}
         run: >-
           cargo hack --each-feature --keep-going \
-            build --target=${{ matrix.target }} --release
+            build --target=${{ matrix.target }} --release \
+            $BUILD_STD_FLAGS
 
   check-release-script:
     name: check release script

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased] ##
 
+### Fixed ###
+- Fixed build failures on s390x with musl libc. The type of `struct statfs`'s
+  `f_type` field is not always the same as `rustix::fs::FsWord` (on
+  s390x-musl, `f_type` is a `u32` while `FsWord` is a `u64`), so comparing the
+  two would not compile. We now always compare filesystem magic numbers as
+  `u64`s. (#425)
+
 ## [0.2.6] - 2026-09-05 ##
 
 > "If only, if only," the woodpecker sighs,

--- a/src/procfs.rs
+++ b/src/procfs.rs
@@ -78,7 +78,7 @@ use std::{
 
 use once_cell::sync::{Lazy, OnceCell as OnceLock};
 use rustix::{
-    fs::{self as rustix_fs, Access, AtFlags},
+    fs::{Access, AtFlags},
     mount::{FsMountFlags, FsOpenFlags, MountAttrFlags, OpenTreeFlags},
 };
 
@@ -972,21 +972,26 @@ impl ProcfsHandle {
     }
 }
 
+/// The magic number of procfs (`PROC_SUPER_MAGIC` in `<linux/magic.h>`).
+///
+/// NOTE: We can't use [`rustix::fs::PROC_SUPER_MAGIC`] because its type
+/// ([`rustix::fs::FsWord`]) is not always the same as the type of
+/// `statfs.f_type`, so we would not be able to compare the two on every
+/// target. See [`syscalls::fstatfs_type`] for more details.
+pub(crate) const PROC_SUPER_MAGIC: u64 = 0x0000_9fa0;
+
 pub(crate) fn verify_is_procfs(fd: impl AsFd) -> Result<(), Error> {
-    let fs_type = syscalls::fstatfs(fd)
-        .map_err(|err| ErrorImpl::RawOsError {
-            operation: "fstatfs proc handle".into(),
-            source: err,
-        })?
-        .f_type;
-    if fs_type != rustix_fs::PROC_SUPER_MAGIC {
+    let fs_type = syscalls::fstatfs_type(fd).map_err(|err| ErrorImpl::RawOsError {
+        operation: "fstatfs proc handle".into(),
+        source: err,
+    })?;
+    if fs_type != PROC_SUPER_MAGIC {
         Err(ErrorImpl::OsError {
             operation: "verify fd is from procfs".into(),
             source: IOError::from_raw_os_error(libc::EXDEV),
         })
         .wrap(format!(
-            "fstype mismatch in restricted procfs resolver (f_type is 0x{fs_type:X}, not 0x{:X})",
-            rustix_fs::PROC_SUPER_MAGIC,
+            "fstype mismatch in restricted procfs resolver (f_type is 0x{fs_type:X}, not 0x{PROC_SUPER_MAGIC:X})",
         ))?
     }
     Ok(())

--- a/src/syscalls.rs
+++ b/src/syscalls.rs
@@ -670,6 +670,23 @@ pub(crate) fn fstatfs(fd: impl AsFd) -> Result<StatFs, Error> {
     })
 }
 
+/// Wrapper for `fstatfs(2)` that only returns the filesystem type
+/// (`statfs.f_type`), widened to a [`u64`].
+///
+/// The exact type of `statfs.f_type` depends on both the architecture and the
+/// backend used by rustix, and is not always the same type as
+/// [`rustix::fs::FsWord`] (on s390x with musl, `f_type` is a `u32` while
+/// `FsWord` is a `u64`), which means that comparing `f_type` against
+/// `FsWord`-typed constants (such as [`rustix::fs::PROC_SUPER_MAGIC`]) doesn't
+/// compile on all targets. Widening the value to a `u64` lets us compare it
+/// against plain `u64` filesystem magic numbers everywhere.
+// The filesystem magic numbers we care about all fit inside a u32, so the
+// signedness of f_type (it is signed on most targets) is irrelevant here.
+#[allow(clippy::unnecessary_cast)]
+pub(crate) fn fstatfs_type(fd: impl AsFd) -> Result<u64, Error> {
+    fstatfs(fd).map(|statfs| statfs.f_type as u64)
+}
+
 /// Wrapper for `fstatat(2)`, which auto-sets `AT_NO_AUTOMOUNT |
 /// AT_SYMLINK_NOFOLLOW | AT_EMPTY_PATH`.
 ///

--- a/src/utils/fd.rs
+++ b/src/utils/fd.rs
@@ -234,9 +234,9 @@ fn proc_subpath<Fd: AsRawFd>(fd: Fd) -> Result<String, Error> {
 /// [kcommit-a481f4d91783]: https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=a481f4d917835cad86701fc0d1e620c74bb5cd5f
 // TODO: Remove the explicit size once generic_arg_infer is stable.
 //       <https://github.com/rust-lang/rust/issues/85077>
-const DANGEROUS_FILESYSTEMS: [rustix_fs::FsWord; 2] = [
-    rustix_fs::PROC_SUPER_MAGIC, // procfs
-    0x5a3c_69f0,                 // apparmorfs
+const DANGEROUS_FILESYSTEMS: [u64; 2] = [
+    procfs::PROC_SUPER_MAGIC, // procfs
+    0x5a3c_69f0,              // apparmorfs
 ];
 
 impl<Fd: AsFd> FdExt for Fd {
@@ -304,11 +304,11 @@ impl<Fd: AsFd> FdExt for Fd {
         // nd_jump_link() is used internally. So, we just have to make an
         // educated guess based on which mainline filesystems expose
         // magic-links.
-        let stat = syscalls::fstatfs(self).map_err(|err| ErrorImpl::RawOsError {
+        let fs_type = syscalls::fstatfs_type(self).map_err(|err| ErrorImpl::RawOsError {
             operation: "check fstype of fd".into(),
             source: err,
         })?;
-        Ok(DANGEROUS_FILESYSTEMS.contains(&stat.f_type))
+        Ok(DANGEROUS_FILESYSTEMS.contains(&fs_type))
     }
 
     fn get_fdinfo_field<T: FromStr>(


### PR DESCRIPTION
libpathrs does not compile on s390x with musl:

    error[E0308]: mismatched types
       --> src/procfs.rs:982:19
        |
    982 |     if fs_type != rustix_fs::PROC_SUPER_MAGIC {
        |        -------    ^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `u32`, found `u64`

The type of "struct statfs"'s f_type field is not always the same as
rustix::fs::FsWord. s390x uses rustix's libc backend, where FsWord is a
u64 for musl, but the libc crate declares statfs.f_type as a c_uint on
s390x-musl -- so the two cannot be compared. (This only happens on musl;
on s390x-gnu both types are u32s, which is why nobody noticed.)

Rather than relying on those two types matching, add a fstatfs_type()
wrapper that widens statfs.f_type to a u64 and use our own u64 constants
for the filesystem magic numbers, so that the comparisons compile
regardless of which architecture and rustix backend we are built for.

Our check-cross matrix only contained s390x-unknown-linux-gnu, so it
could never have caught this -- add s390x-unknown-linux-musl as well.
rustup does not distribute a pre-built libstd for that target (it is
tier 3), so that matrix entry uses nightly Rust and -Zbuild-std to build
libstd itself.

Fixes #425

- - -

Test: `docker build --platform amd64,arm64,ppc64le,s390x,riscv64,linux/arm/v6,linux/arm/v7 .`
```dockerfile
ARG ALPINE_VERSION=3.24.1
ARG LIBPATHRS_REPO=https://github.com/AkihiroSuda/libpathrs.git
ARG LIBPATHRS_VERSION=fix-425

FROM --platform=$BUILDPLATFORM alpine:${ALPINE_VERSION}
RUN apk add --no-cache cargo rust git

ARG LIBPATHRS_REPO
ARG LIBPATHRS_VERSION
ADD --keep-git-dir=true "$LIBPATHRS_REPO#$LIBPATHRS_VERSION" libpathrs
WORKDIR /libpathrs

ARG TARGETARCH
ARG TARGETVARIANT
RUN set -ex; \
    case "$TARGETARCH/$TARGETVARIANT" in \
      amd64/*)     apk_arch=x86_64;  triple=x86_64-alpine-linux-musl           ;; \
      arm64/*)     apk_arch=aarch64; triple=aarch64-alpine-linux-musl          ;; \
      arm/v6)      apk_arch=armhf;   triple=armv6-alpine-linux-musleabihf      ;; \
      arm/v7|arm/) apk_arch=armv7;   triple=armv7-alpine-linux-musleabihf      ;; \
      ppc64le/*)   apk_arch=ppc64le; triple=powerpc64le-alpine-linux-musl      ;; \
      s390x/*)     apk_arch=s390x;   triple=s390x-alpine-linux-musl            ;; \
      riscv64/*)   apk_arch=riscv64; triple=riscv64-alpine-linux-musl          ;; \
      *) echo "unsupported platform $TARGETARCH/$TARGETVARIANT" >&2; exit 1 ;; \
    esac; \
    rustc --print target-list | grep -qx "$triple" \
      || { echo "rustc has no target spec for $triple" >&2; exit 1; }; \
    mkdir -p /sysroot/etc/apk/keys; \
    cp /etc/apk/repositories /sysroot/etc/apk/; \
    echo "$apk_arch" >/sysroot/etc/apk/arch; \
    apk add --no-cache --initdb --root /sysroot --allow-untrusted alpine-keys; \
    apk add --no-cache --root /sysroot rust; \
    ln -s "/sysroot/usr/lib/rustlib/$triple" \
          "$(rustc --print sysroot)/lib/rustlib/$triple"; \
    cargo build --target "$triple"
```
